### PR TITLE
Put \label after \caption in case of figure

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -102,9 +102,9 @@ All rules are meant to be broken (for good reasons). Use this template as just t
 \newpage
 \section{Figures}\label{figures}
 \begin{figure}[H]
-\label{fig:figure1}
 \includegraphics[width=5.25in]{figures/testPicture.jpg}
 \caption{\textbf{Here is the title of my caption} Here is text describing each panel in this figure. This is a photograph by Bob Brewer and incidentally this is how you typeset a URL: \url{https://unsplash.com/photos/sFsumfD7Pbs}}
+\label{fig:figure1}
 \end{figure}
 \newpage
 \section{Tables}
@@ -184,11 +184,11 @@ The redefinitions below will make sure that your supplementary figures and table
 \newpage
 \subsection*{Supplementary Figures}
 \begin{figure}[H]
-\label{fig:supplementaryfigure1}
 \begin{center}
 \includegraphics[width=3.25in]{figures/supplementaryTest.jpg}
 \end{center}
 \caption{\textbf{Here is a VERTICAL figure that I have CENTERED.} Here is text describing each panel in this figure. This is a photograph by Andreas Dress and you can find the original here: \url{https://unsplash.com/photos/NNe6epzHGm8}}
+\label{fig:supplementaryfigure1}
 \end{figure}
 \newpage
 \subsection*{Supplementary Tables}


### PR DESCRIPTION
Reference to a figure displays the containing chapter instead of the numbered figure. Placing the figure's label after the figure's caption solves the issue.

https://www.overleaf.com/learn/latex/Referencing_Figures
